### PR TITLE
Fix 'a non well formed numeric value encountered' errors

### DIFF
--- a/php/system.php
+++ b/php/system.php
@@ -280,6 +280,9 @@ function getCpuLoadData(&$errors)
 
         $cpuloaddata = array_map(
             function ($value, $cores) {
+                $value = floatval($value);
+                $cores = intval($cores);
+
                 $v = (int)($value * 100 / $cores);
                 if ($v > 100)
                     $v = 100;
@@ -318,6 +321,9 @@ function getRamInfo(&$errors)
 
         array_push($errors, "Could not read RAM data: total memory");
     }
+
+    $total = floatval($total);
+    $free = floatval($free);
 
     // Used
     $used = $total - $free;
@@ -380,6 +386,9 @@ function getSwapData(&$errors)
 
         $total = 0;
     }
+
+    $total = floatval($total);
+    $free = floatval($total);
 
     // Used
     $used = $total - $free;

--- a/php/utils.php
+++ b/php/utils.php
@@ -62,6 +62,8 @@ function whichCommand($cmds, $args = '', $returnWithArgs = true)
  */
 function getHumanTime($seconds)
 {
+    $seconds = intval($seconds);
+
     $units = array(
         'year'   => 365*86400,
         'day'    => 86400,


### PR DESCRIPTION
Using PHP 7.2 throws the following "Notice" errors:

```
Notice: A non well formed numeric value encountered in /home/liam/Git/swmp/php/utils.php on line 77

Notice: A non well formed numeric value encountered in /home/liam/Git/swmp/php/utils.php on line 77

Notice: A non well formed numeric value encountered in /home/liam/Git/swmp/php/utils.php on line 86

Notice: A non well formed numeric value encountered in /home/liam/Git/swmp/php/system.php on line 283

Notice: A non well formed numeric value encountered in /home/liam/Git/swmp/php/system.php on line 323

Notice: A non well formed numeric value encountered in /home/liam/Git/swmp/php/system.php on line 328

Notice: A non well formed numeric value encountered in /home/liam/Git/swmp/php/system.php on line 334

Notice: A non well formed numeric value encountered in /home/liam/Git/swmp/php/system.php on line 385

Notice: A non well formed numeric value encountered in /home/liam/Git/swmp/php/system.php on line 385

Notice: A non well formed numeric value encountered in /home/liam/Git/swmp/php/system.php on line 390

Notice: A non well formed numeric value encountered in /home/liam/Git/swmp/php/system.php on line 390

Notice: A non well formed numeric value encountered in /home/liam/Git/swmp/php/system.php on line 394

Notice: A non well formed numeric value encountered in /home/liam/Git/swmp/php/system.php on line 395
```

This PR fixes the problem by converting to int / float prior to the calculation.